### PR TITLE
Add script to subscribe all accounts

### DIFF
--- a/scripts/functions.py
+++ b/scripts/functions.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from telethon.sessions import StringSession
 from telethon.sync import TelegramClient
 from telethon.tl.functions.channels import JoinChannelRequest
+from telethon.errors import rpcerrorlist
 import gspread
 
 from config.telegram import API_ID, API_HASH
@@ -39,7 +40,9 @@ def join_grp(grp_name, str_sess):
         try:
             client(JoinChannelRequest(grp_name))
             return True
-        except:
+        except rpcerrorlist.UserAlreadyParticipantError:
+            return True
+        except Exception:
             return False
 
 def get_gspread(url,filename="scripts/cred.json"):

--- a/scripts/subscribe_all.py
+++ b/scripts/subscribe_all.py
@@ -1,0 +1,20 @@
+import os
+import django
+import sys
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+django.setup()
+
+from accounts.models import Account
+from scripts.functions import join_grp
+
+if len(sys.argv) != 2:
+    print("Usage: python scripts/subscribe_all.py <channel>")
+    sys.exit(1)
+
+channel = sys.argv[1]
+
+for acc in Account.objects.all():
+    success = join_grp(channel, acc.sess_str)
+    status = "joined" if success else "failed"
+    print(f"{acc.acc_name}: {status}")


### PR DESCRIPTION
## Summary
- handle already-subscribed error in `join_grp`
- add utility `subscribe_all.py` to join all accounts to a channel

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b869385dc83229586b6af211e89f7